### PR TITLE
date set as today and add links (repo, pdf, issue) on the web version

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -18,10 +18,11 @@ book:
     - name: Andrzej Młodak
     - name: Johannes Gussenbauer
     - name: Kamil Wilak
-  #date: today
-  date: 2024/08/31  # Temporarily keep date of first release of second edition, change back to "today" for future releases
+  date: today
   date-format: YYYY, MMMM
-  repo-url: https://sdcTools.github.io/HandbookSDC
+  repo-url: https://github.com/sdcTools/HandbookSDC
+  issue-url: https://github.com/sdcTools/HandbookSDC/issues
+  repo-actions: [issue]
   chapters:
     - index.qmd
     - 01-Introduction.qmd
@@ -32,6 +33,7 @@ book:
     - 06-remote-access-issues.qmd
     - 07-glossary.qmd
   page-navigation: true
+  downloads: [pdf]
 
 # bibliography: references.bib
 

--- a/_titlepage.tex
+++ b/_titlepage.tex
@@ -38,9 +38,8 @@
 	
 	{\huge\bfseries\setstretch{1.5} \rule[-0.25cm]{0pt}{0.25cm}$title$}\\[0.4cm] % Title of your document
 	{\large\bfseries\setstretch{1.5} $subtitle$}\\[0.4cm]
-	%{\large\monthyeardate\today}\\[0.4cm] % Date, change the \today to a set date if you want to be precise
- 	{\large\monthyeardate{August, 2024}}\\[0.4cm] % Date of first release of the second edition
-
+	{\large\monthyeardate\today}\\[0.4cm] % Date, change the \today to a set date if you want to be precise
+ 	
 	\HRule\\[1.5cm]
 	
 	%------------------------------------------------


### PR DESCRIPTION
The date version of the document is now set to 'today' in both html and pdf versions.

- Links added on the top left (repo and pdf download):
![image](https://github.com/user-attachments/assets/4adf6272-20a8-4cf8-b3f0-0efe3585203f)

- Links added on the right, below the table of content of the page (a link to report an issue):
![image](https://github.com/user-attachments/assets/2c11d287-cc9b-467d-85dd-33a7d57cec92)
